### PR TITLE
Add external service communication

### DIFF
--- a/engine/camunda/src/main/java/org/camunda/bpm/delegate/ServiceTask.java
+++ b/engine/camunda/src/main/java/org/camunda/bpm/delegate/ServiceTask.java
@@ -1,0 +1,49 @@
+package org.camunda.bpm.delegate;
+
+import kong.unirest.HttpResponse;
+import kong.unirest.JsonNode;
+import kong.unirest.Unirest;
+import org.camunda.bpm.engine.delegate.BpmnError;
+import org.camunda.bpm.engine.delegate.DelegateExecution;
+import org.camunda.bpm.engine.delegate.JavaDelegate;
+import org.camunda.bpm.model.bpmn.instance.BpmnModelElementInstance;
+import org.camunda.bpm.model.bpmn.instance.ServiceTask;
+
+
+public class ServiceTaskEntry implements JavaDelegate {
+
+    @Override
+    public void execute(DelegateExecution execution) throws Exception {
+//        isTaskImplementationValid(execution);
+        try {
+            String apiServiceType = (String) execution.getVariable("apiType");
+            execution.setVariable("detailedErrorInfo", null);
+            String processInstanceId = execution.getProcessInstanceId();
+            String taskDefinitionKey = execution.getCurrentActivityId();
+
+
+            HttpResponse<JsonNode> httpResponse = Unirest.post("http://workflowcapabilities:5003" +
+                            "/RequestServiceTask/" + processInstanceId + "/" +
+                            taskDefinitionKey + "/" + processInstanceId + "/" + apiServiceType)
+                    .asJson();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void isTaskImplementationValid(DelegateExecution execution) {
+        BpmnModelElementInstance modelInstance = execution.getBpmnModelInstance().getModelElementById(execution.getCurrentActivityId());
+        String taskName = execution.getCurrentActivityName();
+
+        if (modelInstance instanceof ServiceTask) {
+            ServiceTask serviceTask = (ServiceTask) modelInstance;
+            String implementationType = serviceTask.getCamundaType();
+
+            if (!"expression".equals(implementationType)) {
+                String message = "Only expression type is supported for service tasks. Cause: " + taskName;
+                execution.setVariable("errorMessage", message);
+                throw new BpmnError("UNSUPPORTED_TYPE", message);
+            }
+        }
+    }
+}

--- a/engine/camunda/src/main/java/org/camunda/bpm/delegate/UserTaskEntry.java
+++ b/engine/camunda/src/main/java/org/camunda/bpm/delegate/UserTaskEntry.java
@@ -3,10 +3,18 @@ package org.camunda.bpm.delegate;
 import kong.unirest.HttpResponse;
 import kong.unirest.JsonNode;
 import kong.unirest.Unirest;
+import kong.unirest.json.JSONObject;
+import org.camunda.bpm.engine.ProcessEngines;
+import org.camunda.bpm.engine.RepositoryService;
 import org.camunda.bpm.engine.delegate.DelegateTask;
 import org.camunda.bpm.engine.delegate.TaskListener;
+import org.camunda.bpm.model.bpmn.BpmnModelInstance;
+import org.camunda.bpm.model.bpmn.instance.UserTask;
+import org.camunda.bpm.model.bpmn.instance.camunda.CamundaExecutionListener;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 
 public class UserTaskEntry implements TaskListener {
@@ -21,9 +29,39 @@ public class UserTaskEntry implements TaskListener {
             e.printStackTrace();
         }
 
-        HttpResponse<JsonNode> httpResponse = Unirest.post(properties.getProperty("wfc.url") +
-                "/RequestUserTask/" + delegateTask.getProcessInstanceId() + "/" +
-                delegateTask.getTaskDefinitionKey() + "/" + delegateTask.getId()).asJson();
+        String expression = getExpressionsFromUserTask(delegateTask);
+        String taskName = delegateTask.getName();
 
+        JSONObject json = new JSONObject();
+        json.put("taskName", taskName);
+        json.put("apiType", expression);
+
+        HttpResponse<JsonNode> httpResponse = Unirest.post(properties.getProperty("wfc.url") +
+                        "/RequestUserTask/" + delegateTask.getProcessInstanceId() + "/" +
+                        delegateTask.getTaskDefinitionKey() + "/" + delegateTask.getId())
+                .body(json)
+                .asJson();
+
+    }
+
+    /**
+     * Extracts the expression of type 'expression' from the user task.
+     *
+     * @param delegateTask The delegate task from which to extract the expression.
+     * @return The extracted expression or an empty string if not found.
+     */
+    private String getExpressionsFromUserTask(DelegateTask delegateTask) {
+        RepositoryService repositoryService = ProcessEngines.getDefaultProcessEngine().getRepositoryService();
+        BpmnModelInstance bpmnModelInstance = repositoryService.getBpmnModelInstance(delegateTask.getProcessDefinitionId());
+        UserTask userTask = (UserTask) bpmnModelInstance.getModelElementById(delegateTask.getTaskDefinitionKey());
+
+        List<CamundaExecutionListener> listeners = userTask.getExtensionElements().getElementsQuery().filterByType(CamundaExecutionListener.class).list();
+
+        if (!listeners.isEmpty()) {
+            CamundaExecutionListener executionListener = listeners.get(0);
+            return executionListener.getCamundaExpression();
+        }
+
+        return "";
     }
 }

--- a/workflow_capability_core/pom.xml
+++ b/workflow_capability_core/pom.xml
@@ -66,6 +66,12 @@
             <version>13.0</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/workflow_capability_core/src/main/java/com/philips/healthsuite/workflowcapability/core/demos/FhirStoreInitialization.java
+++ b/workflow_capability_core/src/main/java/com/philips/healthsuite/workflowcapability/core/demos/FhirStoreInitialization.java
@@ -1,10 +1,14 @@
 package com.philips.healthsuite.workflowcapability.core.demos;
 
 import com.philips.healthsuite.workflowcapability.core.fhirresources.FhirDataResources;
+import org.hl7.fhir.r4.model.StringType;
 import org.hl7.fhir.r4.model.Subscription;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
 
 
 /**
@@ -28,6 +32,7 @@ public class FhirStoreInitialization {
 
         addTaskSubscription();
         addCarePlanSubscription();
+        addMedicationStatementSubscription();
     }
 
 
@@ -40,6 +45,25 @@ public class FhirStoreInitialization {
                 .setType(Subscription.SubscriptionChannelType.RESTHOOK)
                 .setEndpoint(wfcUrl + "/OnTaskChange"));
         fhirDataResources.addResource(taskSubscription);
+    }
+
+    public void addMedicationStatementSubscription() {
+        Subscription medicationSubscription = new Subscription();
+        medicationSubscription.setStatus(Subscription.SubscriptionStatus.REQUESTED);
+        medicationSubscription.setReason("Trigger when a MedicationStatement is completed");
+        medicationSubscription.setCriteria("MedicationStatement?status=completed");
+
+        Subscription.SubscriptionChannelComponent channel = new Subscription.SubscriptionChannelComponent();
+        channel.setType(Subscription.SubscriptionChannelType.RESTHOOK);
+        channel.setEndpoint(wfcUrl + "/MedicationStatementChange");
+        channel.setPayload("application/fhir+json");
+
+        List<StringType> headers = new ArrayList<>();
+        headers.add(new StringType("Content-Type: application/fhir+json"));
+
+        channel.setHeader(headers);
+        medicationSubscription.setChannel(channel);
+        fhirDataResources.addResource(medicationSubscription);
     }
 
 

--- a/workflow_capability_core/src/main/java/com/philips/healthsuite/workflowcapability/core/knowledgemodelmanager/KnowledgeModelController.java
+++ b/workflow_capability_core/src/main/java/com/philips/healthsuite/workflowcapability/core/knowledgemodelmanager/KnowledgeModelController.java
@@ -234,6 +234,7 @@ public class KnowledgeModelController {
         CamundaXMLModifier modifier = new CamundaXMLModifier(xmlFile);
         modifier.addStartEventListener();
         modifier.addUserTaskListener();
+        modifier.addServiceTaskListener();
         modifier.addReceiveTaskListener();
         modifier.addEndEventListener();
         return modifier.saveBPMNModel();

--- a/workflow_capability_core/src/main/java/com/philips/healthsuite/workflowcapability/core/knowledgemodelmanager/camundaInterface/CamundaXMLModifier.java
+++ b/workflow_capability_core/src/main/java/com/philips/healthsuite/workflowcapability/core/knowledgemodelmanager/camundaInterface/CamundaXMLModifier.java
@@ -58,6 +58,13 @@ public class CamundaXMLModifier {
 
     }
 
+    public void addServiceTaskListener() {
+        NodeList tasks = this.getServiceTasks();
+        for (int i = 0; i < tasks.getLength(); i++) {
+            addListenerToNode(tasks.item(i), "org.camunda.bpm.delegate.ServiceTaskEntry", "startExecutionListener");
+        }
+    }
+
     /**
      * Adds the StartEventDelegate reference to the Receive Task in the BPMN XML Definition
      */
@@ -90,6 +97,10 @@ public class CamundaXMLModifier {
 
     private NodeList getUserTasks() {
         return doc.getElementsByTagName("bpmn:userTask");
+    }
+
+    private NodeList getServiceTasks() {
+        return doc.getElementsByTagName("bpmn:serviceTask");
     }
 
     public void addListenerToNode(Node node, String classString, String type) {

--- a/workflow_capability_core/src/main/java/com/philips/healthsuite/workflowcapability/core/wfcservice/EngineInterface.java
+++ b/workflow_capability_core/src/main/java/com/philips/healthsuite/workflowcapability/core/wfcservice/EngineInterface.java
@@ -40,4 +40,6 @@ public interface EngineInterface {
      * @param variableJson The JSON value of the payload variable
      */
     void sendMessage(String messageID, String processID, String variableName, String variableJson);
+
+    void sendVariable(String processID, String variableName, Integer variableValue);
 }


### PR DESCRIPTION
1) Add a MedicationStatement change listener to update total value of administered medicine and utilize this information in workflow. In process variable the information be available by "{medicineName}Total"

2) Update User task to handle external services call
In order to enable User task to call to external services the external service has to subscribe to the tasks updates and the ExecutionListener of User task has to be set
Event type: start
Listener type: expression
Expression: user specified name for the service
Subscribed task can be filtered based on expression value

3) Add service task
To use service task external app has to subscribe to task updates based on apiType variable. apiType variable should be specified for ServiceTask in bpmn by setting Implementation type: expression, value: ${apiType} and setting input variable with name: apiType, Assignment type: string or expression, value: user_specified_name