### PR TITLE
cleaning config file,  adding non interrupting message event to wfc, and other fixes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,46 @@
+version: '3.7'
+
+services:
+  fhir:
+    image: hapiproject/hapi:latest
+    ports:
+      - "8180:8080"
+    environment:
+      - hapi.fhir.subscription.resthook_enabled=true
+    networks:
+      - hswfc
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:8080/fhir/metadata"]
+      interval: 60s
+      timeout: 10s
+      retries: 3
+
+  camunda:
+    build:
+      context: ./engine/camunda
+    image: camunda-engine
+    ports:
+      - "8080:8080"
+    networks:
+      - hswfc
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:8080/engine-rest/engine"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  wfc:
+    build:
+      context: ./workflow_capability_core
+    image: workflow-capability-core
+    ports:
+      - "5003:5003"
+    networks:
+      - hswfc
+    depends_on:
+      fhir:
+        condition: service_healthy
+
+networks:
+  hswfc:
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,46 +1,63 @@
 version: '3.7'
 
+# Define services
 services:
+  # FHIR server service
   fhir:
+    # Use the latest HAPI FHIR image
     image: hapiproject/hapi:latest
     ports:
       - "8180:8080"
+    # Enable REST hook for subscriptions
     environment:
       - hapi.fhir.subscription.resthook_enabled=true
+    # Connect the service to the hswfc network
     networks:
       - hswfc
+    # Define healthcheck to ensure service is running
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://127.0.0.1:8080/fhir/metadata"]
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:8180/fhir/metadata"]
       interval: 60s
       timeout: 10s
       retries: 3
 
+  # Camunda engine service
   camunda:
+    # Build the Camunda engine image from the local context
     build:
       context: ./engine/camunda
+    # Use the built Camunda engine image
     image: camunda-engine
     ports:
       - "8080:8080"
+    # Connect the service to the hswfc network
     networks:
       - hswfc
+    # Define healthcheck to ensure service is running
     healthcheck:
       test: ["CMD", "curl", "-f", "http://127.0.0.1:8080/engine-rest/engine"]
       interval: 30s
       timeout: 10s
       retries: 3
 
+  # Workflow capability core service
   wfc:
+    # Build the workflow capability core image from the local context
     build:
       context: ./workflow_capability_core
+    # Use the built workflow capability core image
     image: workflow-capability-core
     ports:
       - "5003:5003"
+    # Connect the service to the hswfc network
     networks:
       - hswfc
+    # Ensure FHIR service is healthy before starting this service
     depends_on:
       fhir:
         condition: service_healthy
 
+# Define network for communication between services
 networks:
   hswfc:
     driver: bridge

--- a/engine/camunda/Dockerfile
+++ b/engine/camunda/Dockerfile
@@ -1,13 +1,17 @@
+# Use the Maven image as the builder stage
 FROM maven:3.8.6-openjdk-11 as builder
 
 WORKDIR /app
-
 COPY . /app
 
+# Build the application using Maven
 RUN mvn -B package --file pom.xml
 
+# Create a new stage with the OpenJDK 11 JRE slim image
 FROM openjdk:11-jre-slim
-WORKDIR /app
-COPY --from=builder /app/target/camunda_engine-0.0.2-SNAPSHOT.jar /app
 
-CMD ["java", "-jar", "camunda_engine-0.0.2-SNAPSHOT.jar"]
+# Set the working directory for the final image
+WORKDIR /app
+
+COPY --from=builder /app/target/camunda_engine-0.0.2-snapshot.jar /app
+CMD ["java", "-jar", "camunda_engine-0.0.2-snapshot.jar"]

--- a/engine/camunda/Dockerfile
+++ b/engine/camunda/Dockerfile
@@ -1,17 +1,13 @@
-# Use the Maven image as the builder stage
 FROM maven:3.8.6-openjdk-11 as builder
 
 WORKDIR /app
+
 COPY . /app
 
-# Build the application using Maven
 RUN mvn -B package --file pom.xml
 
-# Create a new stage with the OpenJDK 11 JRE slim image
 FROM openjdk:11-jre-slim
-
-# Set the working directory for the final image
 WORKDIR /app
+COPY --from=builder /app/target/camunda_engine-0.0.2-SNAPSHOT.jar /app
 
-COPY --from=builder /app/target/camunda_engine-0.0.2-snapshot.jar /app
-CMD ["java", "-jar", "camunda_engine-0.0.2-snapshot.jar"]
+CMD ["java", "-jar", "camunda_engine-0.0.2-SNAPSHOT.jar"]

--- a/engine/camunda/README.md
+++ b/engine/camunda/README.md
@@ -6,11 +6,10 @@
 	
 ## Run
 - Change directory to the main folder of Camunda engine:  `cd engine/camunda`
-- Run the created .jar file in the target folder:  `java -jar target/camunda_engine-0.0.2-SNAPSHOT.jar`  
-	-  `java -Djava.net.preferIPv4Stack=true -jar target/camunda_engine-0.0.2-SNAPSHOT.jar`
-- Access Camunda web interface at: http://localhost:8080/. The login credentials are:  
-	-- *User Name:* admin  
+- Run the created .jar file in the target folder:  `java -jar target/camunda_engine-0.0.2-SNAPSHOT.jar`
+- Access Camunda web interface at: http://localhost:8080/. The login credentials are:
+	-- *User Name:* admin
 	-- *Password:* geheim
-# To use docker  
+# To use docker
 - docker build -t camunda-engine .
 - docker run -p 8080:8080 camunda-engine

--- a/engine/camunda/README.md
+++ b/engine/camunda/README.md
@@ -7,6 +7,7 @@
 ## Run
 - Change directory to the main folder of Camunda engine:  `cd engine/camunda`
 - Run the created .jar file in the target folder:  `java -jar target/camunda_engine-0.0.2-SNAPSHOT.jar`  
+	-  `java -Djava.net.preferIPv4Stack=true -jar target/camunda_engine-0.0.2-SNAPSHOT.jar`
 - Access Camunda web interface at: http://localhost:8080/. The login credentials are:  
 	-- *User Name:* admin  
 	-- *Password:* geheim

--- a/engine/camunda/src/main/java/org/camunda/bpm/delegate/InterfaceWfcHandler.java
+++ b/engine/camunda/src/main/java/org/camunda/bpm/delegate/InterfaceWfcHandler.java
@@ -1,5 +1,6 @@
 package org.camunda.bpm.delegate;
 
+import java.io.IOException;
 import java.util.Collection;
 import java.util.Properties;
 import java.util.logging.Logger;
@@ -25,87 +26,110 @@ import kong.unirest.Unirest;
 /*
 * VariableAccessor functional interface is providing a flexible way to access process variables from both DelegateTask and DelegateExecution contexts in this program. 
 * It enhances code reusability and flexibility, allowing the same query processing logic to be applied in various parts of the program without duplicating code.
-*/ 
+*/
+
 @FunctionalInterface
 interface VariableAccessor {
     Object getVariable(String name);
 }
+
 /**
- * This class is used to handle the interface between the workflow capability and the workflow engine 
+ * In general, This class is used to handle the interface between the workflow capability and the workflow engine:
  * It is used to handle the boundary message events and the data object reference in the workflow engine
- * It is also used to create user tasks in the workflow engine
- * 
+ * It is also used to send user tasks to the wfc, so that it will be created in the FHIR store.
+ *
  */
+
 public class InterfaceWfcHandler {
-private final Logger logger = Logger.getLogger(InterfaceWfcHandler.class.getName());
+    private final Logger logger = Logger.getLogger(InterfaceWfcHandler.class.getName());
+    private final Properties properties = new Properties();
 
-/* 
- * This method is used to process the query and replace the process variables with the actual values
- */
-private String processQuery(String query, VariableAccessor variableAccessor) {
-    StringBuffer sb = new StringBuffer();
-    Pattern pattern = Pattern.compile("\\$\\((\\w+)\\)");
-    Matcher matcher = pattern.matcher(query);
-    while (matcher.find()) {
-        String variableName = matcher.group(1);
-        logger.info("The required variable is: " + variableName);
-        String replacement;
-        if (variableName.equals("NOW") || variableName.startsWith("MOMENT")) {
-            logger.info("The moment in variable is: " + variableName);
-            replacement = "$(" + variableName + ")";
-        } else {
-            // replacement = (String) delegateTask.getVariable(variableName);
-            replacement = (String) variableAccessor.getVariable(variableName);
+    /*
+     * loading the application property
+     */
+    public InterfaceWfcHandler() {
+        try {
+            properties.load(getClass().getClassLoader().getResourceAsStream("application.properties"));
+        } catch (IOException e) {
+            logger.warning("Failed to load application properties: " + e.getMessage());
+            e.printStackTrace();
         }
-        matcher.appendReplacement(sb, Matcher.quoteReplacement(replacement));
     }
-    matcher.appendTail(sb);
-    return sb.toString();
-}
 
-/* 
- *  This method is used to handle the boundary message event interupting message boundary event attached to a user task
- * @param messageBoundaryEvent 
- * @param delegateTask
-*/
-public void handleBoundaryEvent(BoundaryEvent messageBoundaryEvent, DelegateTask delegateTask,
-        Properties properties) {
-    boolean isInterupting = messageBoundaryEvent.cancelActivity();
-    MessageEventDefinition messageEventDefinition = (MessageEventDefinition) messageBoundaryEvent
-            .getEventDefinitions().iterator().next();
-    Message message = messageEventDefinition.getMessage();
-    String messageName = message != null ? message.getName() : "No message";
+    /*
+     * This method is used to process the query and replace the process variables
+     * with the actual values
+     * @param query the query to be processed
+     * @param variableAccessor the variableAccessor functional interface that allows
+     * access to process variables
+    */
 
-    Collection<Documentation> documentations = messageBoundaryEvent.getDocumentations();
-    String documentationText = !documentations.isEmpty() ? documentations.iterator().next().getTextContent()
-            : "No documentation";
+    private String processQuery(String query, VariableAccessor variableAccessor) {
+        StringBuffer sb = new StringBuffer();
+        Pattern pattern = Pattern.compile("\\$\\((\\w+)\\)");
+        Matcher matcher = pattern.matcher(query);
+        while (matcher.find()) {
+            String variableName = matcher.group(1);
+            logger.info("The required variable is: " + variableName);
+            String replacement;
+            if (variableName.equals("NOW") || variableName.startsWith("MOMENT")) {
+                logger.info("The moment in variable is: " + variableName);
+                replacement = "$(" + variableName + ")";
+            } else {
+                // replacement = (String) delegateTask.getVariable(variableName);
+                replacement = (String) variableAccessor.getVariable(variableName);
+            }
+            matcher.appendReplacement(sb, Matcher.quoteReplacement(replacement));
+        }
+        matcher.appendTail(sb);
+        return sb.toString();
+    }
 
-    logger.info("Handling boundary event ID from separate component: " + messageBoundaryEvent.getId()
-            + " with message: " + messageName);
-    String variableName = messageBoundaryEvent.getName();
-    VariableAccessor accessor = varName -> delegateTask.getVariable(varName);
-    String query = processQuery(documentationText, accessor);
-    requestData(query, delegateTask.getProcessInstanceId(), messageName + "", variableName, delegateTask.getId(),
-    properties, isInterupting);
-}
-/*
- * This method is used to handle the data object reference in this implemetation associated with receieve task
- * @param properties, delegateExecution
- */
-public void dataObjectReferenceImpl(Properties properties, DelegateExecution delegateExecution) {
-    VariableAccessor accessor = varName -> delegateExecution.getVariable(varName);
-    String message = "";
-    ReceiveTask receiveTask = null;
-    receiveTask = delegateExecution.getProcessEngine().getRepositoryService()
+    /*
+     * This method is used to handle the boundary message events
+     *
+     * @param messageBoundaryEvent the messageBoundaryEvent attached to the user task
+     * @param delegateTask the delegateTask object
+     *
+     */
+
+    public void handleBoundaryEvent(BoundaryEvent messageBoundaryEvent, DelegateTask delegateTask) {
+        boolean isInterupting = messageBoundaryEvent.cancelActivity();
+        MessageEventDefinition messageEventDefinition = (MessageEventDefinition) messageBoundaryEvent
+                .getEventDefinitions().iterator().next();
+        Message message = messageEventDefinition.getMessage();
+        String messageName = message != null ? message.getName() : "No message";
+
+        Collection<Documentation> documentations = messageBoundaryEvent.getDocumentations();
+        String documentationText = !documentations.isEmpty() ? documentations.iterator().next().getTextContent()
+                : "No documentation";
+        String variableName = messageBoundaryEvent.getName();
+        VariableAccessor accessor = varName -> delegateTask.getVariable(varName);
+        String query = processQuery(documentationText, accessor);
+        requestData(query, delegateTask.getProcessInstanceId(), messageName, variableName, delegateTask.getId(), isInterupting);
+    }
+
+    /*
+     * This method is used to handle the data object reference in this implemetation
+     * associated with receieve task
+     * @param delegateExecution the delegateExecution object
+     */
+
+    public void dataObjectReferenceImpl(DelegateExecution delegateExecution) {
+        VariableAccessor accessor = varName -> delegateExecution.getVariable(varName);
+        String message = "";
+        ReceiveTask receiveTask = null;
+        receiveTask = delegateExecution.getProcessEngine().getRepositoryService()
                 .getBpmnModelInstance(delegateExecution.getProcessDefinitionId())
                 .getModelElementById(delegateExecution.getCurrentActivityId());
-    message = receiveTask.getMessage().getName();
-    String variableName = "";
-    String query = "";
+        message = receiveTask.getMessage().getName();
+        String variableName = "";
+        String query = "";
         BpmnModelInstance bpmModel = delegateExecution.getProcessEngine().getRepositoryService()
                 .getBpmnModelInstance(delegateExecution.getProcessDefinitionId());
         receiveTask = bpmModel.getModelElementById(delegateExecution.getCurrentActivityId());
-        // Get documentation from dataReference, NOTE: Assumed only 1 dataRef with a single documentation is found.
+        // Get documentation from dataReference, NOTE: Assumed only 1 dataRef with a
+        // single documentation is found.
         for (DataInputAssociation dataInputAssociation : receiveTask.getDataInputAssociations()) {
             for (ItemAwareElement source : dataInputAssociation.getSources()) {
                 DataObjectReferenceImpl dataReference = bpmModel.getModelElementById(source.getId());
@@ -115,50 +139,55 @@ public void dataObjectReferenceImpl(Properties properties, DelegateExecution del
                 }
             }
         }
-    query = processQuery(query, accessor);
-    // The task identifier in this case is, cosidered as the task id of the receive task, it is because the receive task is not registered in the database
-    requestData(query, delegateExecution.getProcessInstanceId(), message, variableName, "receiveTask",
-    properties, false);
-}
-
-/*
- * this method is used notfify the wfc to create a user task in the FHIR
- * @param properties
- * @param delegateTask
-*/
-public boolean createUserTask(Properties properties, DelegateTask delegateTask) {
-    try {
-        HttpResponse<JsonNode> httpResponse = Unirest.post(properties.getProperty("wfc.url") +
-                "/RequestUserTask/" + delegateTask.getProcessInstanceId() + "/" +
-                delegateTask.getTaskDefinitionKey() + "/" + delegateTask.getId())
-                .asJson();
-
-        if (httpResponse.getStatus() != 200) {
-            logger.warning("wfc Failed to create UserTask: " + httpResponse.getStatusText());
-            return false;
-        } else
-             return true;
-    } catch (Exception e) {
-        logger.severe("Engine Failed to create UserTask: " + e.getMessage());
-        return false;
+        query = processQuery(query, accessor);
+        /*
+         * The task identifier in this case is, considered as the taskidentifier of the receive task,
+         * it is because the receive task is not registered in the database in this prototype.
+        */
+        requestData(query, delegateExecution.getProcessInstanceId(), message, variableName, "receiveTask", false);
     }
-}
 
-/*
- * This method is used to send the request to the wfc to request data from the FHIR via wfc service
- * @param query
- * @param delegateTask
- * @param messageName
- * @param variableName
- * @param taskIdentifier
- * @param properties
-*/
+    /*
+     * this method is used notfify the wfc to create a user task in the FHIR
+     * @param delegateTask the delegateTask object from  User Task
+     */
 
-private void requestData(String query, String delegateTask, String messageName, String variableName,
-        String taskIdentifier, Properties properties, boolean isInterupting) {
-            String url = properties.getProperty("wfc.url") + "/RequestObservationValue/"
-                    + delegateTask + "/" + messageName + "/" + variableName + "/"
-                    + taskIdentifier + "/" + isInterupting;
-            Unirest.post(url).body(query).asJson();
+    public boolean createUserTask(DelegateTask delegateTask) {
+        try {
+            HttpResponse<JsonNode> httpResponse = Unirest
+                    .post(properties.getProperty("wfc.url") + "/RequestUserTask/" + delegateTask.getProcessInstanceId()
+                            + "/" + delegateTask.getTaskDefinitionKey() + "/" + delegateTask.getId())
+                    .asJson();
+            if (httpResponse.getStatus() != 200) {
+                logger.warning("wfc Failed to create UserTask: " + httpResponse.getStatusText());
+                return false;
+            } else
+                return true;
+        } catch (Exception e) {
+            logger.severe("Engine Failed to create UserTask: " + e.getMessage());
+            return false;
+        }
+    }
+
+    /*
+     * This method is used to send the request to the wfc to request data from the FHIR via wfc service 
+     * @param query the FHIR-query to be sent to the WFC service
+     * @param processInstanceId: the process instance id of the process
+     * @param messageName: the message name
+     * @param variableName: the name (for boundary message event or data object
+     * reference)
+     * @param taskIdentifier: the task identifier
+     *
+     */
+
+    private void requestData(String query, String processInstanceId, String messageName, String variableName,
+            String taskIdentifier, boolean isInterupting) {
+        //// Building the complete URL for the request.
+        String url = properties.getProperty("wfc.url") + "/RequestObservationValue/"
+                + processInstanceId + "/" + messageName + "/" + variableName + "/"
+                + taskIdentifier + "/" + isInterupting;
+        // Sending the request to the WFC service and Unirest is used to send a POST
+        // request to the WFC service.
+        Unirest.post(url).body(query).asJson();
     }
 }

--- a/engine/camunda/src/main/java/org/camunda/bpm/delegate/ReceiveTaskEntry.java
+++ b/engine/camunda/src/main/java/org/camunda/bpm/delegate/ReceiveTaskEntry.java
@@ -1,29 +1,21 @@
 package org.camunda.bpm.delegate;
 
+import java.util.Collection;
+import java.util.logging.Logger;
+
 import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.camunda.bpm.engine.delegate.JavaDelegate;
 import org.camunda.bpm.model.bpmn.BpmnModelInstance;
 import org.camunda.bpm.model.bpmn.instance.BoundaryEvent;
 import org.camunda.bpm.model.bpmn.instance.ReceiveTask;
 
-import java.io.IOException;
-import java.util.Collection;
-import java.util.Properties;
-import java.util.logging.Logger;
-
 public class ReceiveTaskEntry implements JavaDelegate {
     InterfaceWfcHandler interfaceWfcHandler = new InterfaceWfcHandler();
     private static final Logger logger = Logger.getLogger(ReceiveTaskEntry.class.getName());
     @Override
     public void execute(DelegateExecution delegateExecution) throws Exception {
-        Properties properties = new Properties();
-        try {
-            properties.load(getClass().getClassLoader().getResourceAsStream("config.properties"));
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
         ReceiveTask receiveTask;
-        interfaceWfcHandler.dataObjectReferenceImpl(properties, delegateExecution);
+        interfaceWfcHandler.dataObjectReferenceImpl(delegateExecution);
         BpmnModelInstance bpmModel = delegateExecution.getProcessEngineServices().getRepositoryService()
                 .getBpmnModelInstance(delegateExecution.getProcessDefinitionId());
         receiveTask = delegateExecution.getProcessEngine().getRepositoryService()

--- a/engine/camunda/src/main/java/org/camunda/bpm/delegate/UserTaskEntry.java
+++ b/engine/camunda/src/main/java/org/camunda/bpm/delegate/UserTaskEntry.java
@@ -1,15 +1,13 @@
 package org.camunda.bpm.delegate;
 
+import java.util.Collection;
+import java.util.logging.Logger;
+
 import org.camunda.bpm.engine.delegate.DelegateTask;
 import org.camunda.bpm.engine.delegate.TaskListener;
 import org.camunda.bpm.model.bpmn.BpmnModelInstance;
 import org.camunda.bpm.model.bpmn.instance.BoundaryEvent;
 import org.camunda.bpm.model.bpmn.instance.UserTask;
-
-import java.io.IOException;
-import java.util.Collection;
-import java.util.Properties;
-import java.util.logging.Logger;
 
 public class UserTaskEntry implements TaskListener {
     InterfaceWfcHandler interfaceWfcHandler = new InterfaceWfcHandler();
@@ -17,28 +15,17 @@ public class UserTaskEntry implements TaskListener {
 
     @Override
     public void notify(DelegateTask delegateTask) {
-        Properties properties = new Properties();
-        try {
-            properties.load(getClass().getClassLoader().getResourceAsStream("config.properties"));
-
-        } catch (IOException e) {
-
-            logger.severe("Unable to load config file: " + e.getMessage());
-        }
-
         BpmnModelInstance bpmModel = delegateTask.getProcessEngineServices().getRepositoryService()
                 .getBpmnModelInstance(delegateTask.getProcessDefinitionId());
         UserTask userTask = (UserTask) bpmModel.getModelElementById(delegateTask.getTaskDefinitionKey());
-        boolean isUserTaskCreated = interfaceWfcHandler.createUserTask(properties, delegateTask);
+        boolean isUserTaskCreated = interfaceWfcHandler.createUserTask(delegateTask);
         if (isUserTaskCreated) {
             logger.info("User Task  with no boundary event created successfully");
         }
         Collection<BoundaryEvent> boundaryEvents = bpmModel.getModelElementsByType(BoundaryEvent.class);
-        logger.info("Total Boundary Events in model: " + boundaryEvents.size());
-
         BoundaryEvent messageBoundaryEvent = findMessageBoundaryEvent(userTask, boundaryEvents);
         if (messageBoundaryEvent != null) {
-            interfaceWfcHandler.handleBoundaryEvent(messageBoundaryEvent, delegateTask, properties);
+            interfaceWfcHandler.handleBoundaryEvent(messageBoundaryEvent, delegateTask);
         }
     }
 

--- a/pulse-physiology_FHIR/config.ini
+++ b/pulse-physiology_FHIR/config.ini
@@ -2,7 +2,3 @@
 server_url = http://host.docker.internal:8180/fhir
 [TIME_ZONE]
 time_zone = Europe/Amsterdam
-[DATABASE]
-db_host = host.docker.internal
-db_port = 5432
-db_name = pulse

--- a/workflow_capability_core/src/main/java/com/philips/healthsuite/workflowcapability/core/demos/FhirStoreInitialization.java
+++ b/workflow_capability_core/src/main/java/com/philips/healthsuite/workflowcapability/core/demos/FhirStoreInitialization.java
@@ -1,16 +1,14 @@
 package com.philips.healthsuite.workflowcapability.core.demos;
 
-import com.philips.healthsuite.workflowcapability.core.WfcServiceApplication;
-import com.philips.healthsuite.workflowcapability.core.fhirresources.FhirDataResources;
-
 import java.util.logging.Logger;
 
-import org.apache.jena.base.Sys;
-import org.apache.jena.sparql.function.library.leviathan.log;
 import org.hl7.fhir.r4.model.Subscription;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
+
+import com.philips.healthsuite.workflowcapability.core.WfcServiceApplication;
+import com.philips.healthsuite.workflowcapability.core.fhirresources.FhirDataResources;
 
 /**
  * Adds required subscriptions.
@@ -32,12 +30,9 @@ public class FhirStoreInitialization {
         this.wfcUrl = this.env.getProperty("config.wfcUrl");
         this.fhirUrl = this.env.getProperty("config.fhirUrl");
         this.fhirDataResources = new FhirDataResources(this.fhirUrl + "/fhir");
-
         addTaskSubscription();
         addCarePlanSubscription();
-        // addObservationValueChangeSubscription();
     }
-
 
     private void addTaskSubscription() {
         logger.info("Adding Task Subscription");
@@ -50,22 +45,6 @@ public class FhirStoreInitialization {
                 .setEndpoint(wfcUrl + "/OnTaskChange"));
         fhirDataResources.addResource(taskSubscription);
     }
-
-    // public void addObservationValueChangeSubscription() {
-    // Subscription observationValueChangeSubscription = new Subscription();
-    // observationValueChangeSubscription.setStatus(Subscription.SubscriptionStatus.REQUESTED);
-    // observationValueChangeSubscription.setReason("Trigger when the value of an
-    // Observation changes and is greater than zero");
-    // observationValueChangeSubscription.setCriteria("Observation?status=final");
-
-    // // Setting up the channel as per the previous example
-    // observationValueChangeSubscription.setChannel(new
-    // Subscription.SubscriptionChannelComponent()
-    // .setType(Subscription.SubscriptionChannelType.RESTHOOK)
-    // .setEndpoint(wfcUrl + "/OnObservationValueChange"));
-
-    // fhirDataResources.addResource(observationValueChangeSubscription);
-    // }
 
     private void addCarePlanSubscription() {
         logger.info("Adding CarePlan Subscription");

--- a/workflow_capability_core/src/main/java/com/philips/healthsuite/workflowcapability/core/demos/FhirStoreInitialization.java
+++ b/workflow_capability_core/src/main/java/com/philips/healthsuite/workflowcapability/core/demos/FhirStoreInitialization.java
@@ -6,11 +6,11 @@ import com.philips.healthsuite.workflowcapability.core.fhirresources.FhirDataRes
 import java.util.logging.Logger;
 
 import org.apache.jena.base.Sys;
+import org.apache.jena.sparql.function.library.leviathan.log;
 import org.hl7.fhir.r4.model.Subscription;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
-
 
 /**
  * Adds required subscriptions.
@@ -52,19 +52,21 @@ public class FhirStoreInitialization {
     }
 
     // public void addObservationValueChangeSubscription() {
-    //     Subscription observationValueChangeSubscription = new Subscription();
-    //     observationValueChangeSubscription.setStatus(Subscription.SubscriptionStatus.REQUESTED);
-    //     observationValueChangeSubscription.setReason("Trigger when the value of an Observation changes and is greater than zero");
-    //     observationValueChangeSubscription.setCriteria("Observation?status=final");
-    
-    //     // Setting up the channel as per the previous example
-    //     observationValueChangeSubscription.setChannel(new Subscription.SubscriptionChannelComponent()
-    //             .setType(Subscription.SubscriptionChannelType.RESTHOOK)
-    //             .setEndpoint(wfcUrl + "/OnObservationValueChange"));
-    
-    //     fhirDataResources.addResource(observationValueChangeSubscription);
+    // Subscription observationValueChangeSubscription = new Subscription();
+    // observationValueChangeSubscription.setStatus(Subscription.SubscriptionStatus.REQUESTED);
+    // observationValueChangeSubscription.setReason("Trigger when the value of an
+    // Observation changes and is greater than zero");
+    // observationValueChangeSubscription.setCriteria("Observation?status=final");
+
+    // // Setting up the channel as per the previous example
+    // observationValueChangeSubscription.setChannel(new
+    // Subscription.SubscriptionChannelComponent()
+    // .setType(Subscription.SubscriptionChannelType.RESTHOOK)
+    // .setEndpoint(wfcUrl + "/OnObservationValueChange"));
+
+    // fhirDataResources.addResource(observationValueChangeSubscription);
     // }
-    
+
     private void addCarePlanSubscription() {
         logger.info("Adding CarePlan Subscription");
         Subscription carePlanSubscription = new Subscription();

--- a/workflow_capability_core/src/main/java/com/philips/healthsuite/workflowcapability/core/wfcservice/EngineInterface.java
+++ b/workflow_capability_core/src/main/java/com/philips/healthsuite/workflowcapability/core/wfcservice/EngineInterface.java
@@ -40,5 +40,5 @@ public interface EngineInterface {
      * @param variableName The name of the payload variable
      * @param variableJson The JSON value of the payload variable
      */
-    void sendMessage(String messageID, String processID, String variableName, String variableJson);
+    boolean sendMessage(String messageID, String processID, String variableName, String variableJson);
 }


### PR DESCRIPTION
This pull request contains the following: 
Cleaning config file for "pulse-physiology_FHIR" component, adding non interrupting boundary message event to WFC, checking when to complete task in fhir store and when to remove subscribed resource and handle error handling mechanism if no resource when getting data in getResource.
Compose file is added to build and run hapi-fhir, wfc, and camunda-engine at once. 